### PR TITLE
Add Codespaces configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "name": "AI Job Applicant Bot",
+  "image": "mcr.microsoft.com/devcontainers/python:0-3.10",
+  "postCreateCommand": "pip install -r requirements.txt",
+  "forwardPorts": [8501]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.env
+.vscode
+.ipynb_checkpoints/

--- a/README.md
+++ b/README.md
@@ -63,3 +63,9 @@ streamlit run ui/app.py
 ```
 
 Codespaces will forward the default port (8501) so you can open the app directly in your browser, including on mobile devices.
+
+## Developing in GitHub Codespaces
+
+A `.devcontainer` directory is provided so the repository can run directly in GitHub Codespaces.
+To start a Codespace, click the **Code** button on the repository page and choose **Open with Codespaces**.
+The container image installs the required Python dependencies and forwards port `8501` for the Streamlit UI.


### PR DESCRIPTION
## Summary
- add `.devcontainer` with Python 3.10 image
- document how to launch Codespaces
- ignore dev files with a `.gitignore`

## Testing
- `python -m py_compile $(git ls-files '*.py')`