### PR TITLE
Add Codespaces usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,5 @@ Codespaces will forward the default port (8501) so you can open the app directly
 A `.devcontainer` directory is provided so the repository can run directly in GitHub Codespaces.
 To start a Codespace, click the **Code** button on the repository page and choose **Open with Codespaces**.
 The container image installs the required Python dependencies and forwards port `8501` for the Streamlit UI.
+
+For step-by-step instructions, see [Codespaces Guide](codespaces_guide.md).

--- a/codespaces_guide.md
+++ b/codespaces_guide.md
@@ -1,0 +1,34 @@
+# AI Job Applicant Bot - GitHub Codespaces Guide
+
+This guide explains how to open and work with the repository in GitHub Codespaces.
+
+## Launching a Codespace
+
+1. Navigate to the repository on GitHub.
+2. Click the **Code** button and choose **Open with Codespaces**.
+3. Create a new Codespace or select an existing one.
+
+## Dev Container Configuration
+
+The repository contains a `.devcontainer` directory with a `devcontainer.json` file:
+
+```json
+{
+  "name": "AI Job Applicant Bot",
+  "image": "mcr.microsoft.com/devcontainers/python:0-3.10",
+  "postCreateCommand": "pip install -r requirements.txt",
+  "forwardPorts": [8501]
+}
+```
+
+This configuration installs required Python dependencies and forwards port **8501** so the Streamlit UI can run in the Codespace.
+
+## Running the Streamlit UI
+
+Once your Codespace is ready, launch the app from the terminal:
+
+```bash
+streamlit run ui/app.py
+```
+
+GitHub Codespaces will automatically forward port 8501, allowing you to open the Streamlit interface in your browser.


### PR DESCRIPTION
## Summary
- document how to use GitHub Codespaces with this repo
- reference the new guide in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
